### PR TITLE
fix kombu/celery version issue

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,4 +11,4 @@ requests
 future
 
 # for the AI backend
-celery[redis,auth,msgpack]>=4.3.0  #TODO
+celery[redis,auth,msgpack]==4.4.7  #TODO


### PR DESCRIPTION
the celery in other version will face "no module kombu.five" or other issues

I am working with docker-compose mode