### PR TITLE
Pin importlib-metadata==4.13.0

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -10,6 +10,7 @@ numpy
 requests
 # kombu==4.6.11
 celery[redis,auth,msgpack]  #==4.4.7
+importlib-metadata==4.13.0  # https://github.com/python/importlib_metadata/issues/411
 
 # for the AI backend
 opencv-python


### PR DESCRIPTION
Cannot run without this fix. See https://github.com/python/importlib_metadata/issues/411.